### PR TITLE
BoardController에 요청 파라미터 validation 추가

### DIFF
--- a/src/main/java/com/greeny/ecomate/posting/controller/BoardController.java
+++ b/src/main/java/com/greeny/ecomate/posting/controller/BoardController.java
@@ -7,11 +7,14 @@ import com.greeny.ecomate.posting.dto.UpdateBoardRequestDto;
 import com.greeny.ecomate.posting.service.BoardService;
 import com.greeny.ecomate.utils.api.ApiUtil;
 import com.greeny.ecomate.utils.api.ApiUtil.ApiSuccessResult;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
+@Tag(name = "Board(게시물)")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/board")
@@ -20,7 +23,7 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping
-    public ApiUtil.ApiSuccessResult<Long> createBoard(@RequestBody CreateBoardRequestDto createDto) {
+    public ApiUtil.ApiSuccessResult<Long> createBoard(@Valid @RequestBody CreateBoardRequestDto createDto) {
         return ApiUtil.success("게시물 생성 성공", boardService.createBoard(createDto));
     }
 
@@ -30,7 +33,7 @@ public class BoardController {
     }
 
     @PutMapping
-    public ApiUtil.ApiSuccessResult<Long> updateBoard(@RequestBody UpdateBoardRequestDto updateDto) {
+    public ApiUtil.ApiSuccessResult<Long> updateBoard(@Valid @RequestBody UpdateBoardRequestDto updateDto) {
         return ApiUtil.success("게시물 수정 성공", boardService.updateBoard(updateDto));
     }
 

--- a/src/main/java/com/greeny/ecomate/posting/dto/CreateBoardRequestDto.java
+++ b/src/main/java/com/greeny/ecomate/posting/dto/CreateBoardRequestDto.java
@@ -6,18 +6,25 @@ import com.greeny.ecomate.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import javax.validation.constraints.NotNull;
+
 @Data
 @AllArgsConstructor
 public class CreateBoardRequestDto {
 
+    @NotNull
     private String nickname;
 
+    @NotNull
     private Long challengeId;
 
+    @NotNull
     private String boardTitle;
 
+    @NotNull
     private String boardContent;
 
+    @NotNull
     private String image;
 
     public Board toEntity(User user) {

--- a/src/main/java/com/greeny/ecomate/posting/dto/UpdateBoardRequestDto.java
+++ b/src/main/java/com/greeny/ecomate/posting/dto/UpdateBoardRequestDto.java
@@ -2,14 +2,19 @@ package com.greeny.ecomate.posting.dto;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotNull;
+
 @Data
 public class UpdateBoardRequestDto {
     // image, challenge 는 수정 불가
 
+    @NotNull
     private Long boardId;
 
+    @NotNull
     private String boardTitle;
 
+    @NotNull
     private String boardContent;
 
 }

--- a/src/main/java/com/greeny/ecomate/posting/service/BoardService.java
+++ b/src/main/java/com/greeny/ecomate/posting/service/BoardService.java
@@ -57,9 +57,11 @@ public class BoardService {
    }
 
    private void validateChallenge(Long challengeId) {
-      challengeRepository.findById(challengeId)
-              .orElseThrow(() -> new NotFoundException("존재하지 않는 챌린지입니다."));
+      // challengeId == 0 : challenge 미등록
+      if (challengeId != 0) {
+         challengeRepository.findById(challengeId)
+                 .orElseThrow(() -> new NotFoundException("존재하지 않는 챌린지입니다."));
+      }
    }
-
 
 }


### PR DESCRIPTION
resolve #24 

### 추가된 기능
- BoardController의 요청 파라미터를 validation 규정을 NotNull로 설정 -> null이면 MethodMethodArgumentNotValidException 발생

### 수정사항
- 게시물 생성 요청에서 challengeId가 0일 때 `challenge 미등록`인 것으로 변경 (이전에는 challengeId가 null일 때 )
