### PR TITLE
댓글 api의 uri를 복수형으로 수정

### DIFF
--- a/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
+++ b/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/comment")
+@RequestMapping("/v1/comments")
 public class CommentController {
 
     private final CommentService commentService;
@@ -25,7 +25,7 @@ public class CommentController {
         return ApiUtil.success("댓글 생성 성공", commentService.createComment(createRequest));
     }
 
-    @GetMapping("/board/{boardId}")
+    @GetMapping("/boards/{boardId}")
     public ApiUtil.ApiSuccessResult<CommentListDto> getCommentByBoard(@PathVariable Long boardId) {
         return ApiUtil.success("게시물의 댓글 조회 성공", commentService.getCommentByBoard(boardId));
     }


### PR DESCRIPTION
resolve #46 

### 수정 사항
- /v1/comment -> /v1/comments 로 변경
- 게시물 별 조회 api : ~/board/{boardId} -> ~/boards{boardId}