### PR TITLE
사용자 인증에 따른 챌린지 기능 수정

### DIFF
--- a/src/main/java/com/greeny/ecomate/auth/controller/AuthController.java
+++ b/src/main/java/com/greeny/ecomate/auth/controller/AuthController.java
@@ -50,8 +50,8 @@ public class AuthController {
             HttpServletResponse res) throws RuntimeException {
         Member member = authService.signInMember(form);
 
-        String accessToken = jwtProvider.generateMemberToken(member.getEmail(), member.getName() + "");
-        String refreshToken = jwtProvider.generateMemberRefreshToken(member.getEmail(), member.getName() + "");
+        String accessToken = jwtProvider.generateMemberToken(member.getEmail(), member.getMemberId() + "");
+        String refreshToken = jwtProvider.generateMemberRefreshToken(member.getEmail(), member.getMemberId() + "");
 
         ResponseCookie cookie = cookieUtil.createCookie(JwtProvider.ACCOUNT_TOKEN_NAME, refreshToken);
         res.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
@@ -66,6 +66,10 @@ public class ChallengeController {
     public ApiUtil.ApiSuccessResult<Long> updateChallengeActiveYn(@PathVariable Long challengeId,
                                         @RequestBody boolean activeYn,
                                         HttpServletRequest req) {
+
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
         Long memberId = (Long) req.getAttribute("memberId");
         Member member = memberService.getMemberById(memberId);
         challengeService.updateChallengeActiveYn(challengeId, activeYn, member);
@@ -77,6 +81,10 @@ public class ChallengeController {
     public ApiUtil.ApiSuccessResult<Long> updateChallenge(@PathVariable Long challengeId,
                                 @Valid @RequestBody ChallengeDto challengeDto,
                                 HttpServletRequest req) {
+
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
         Long memberId = (Long) req.getAttribute("memberId");
         Member member = memberService.getMemberById(memberId);
         challengeService.updateChallenge(challengeId, challengeDto, member);
@@ -87,6 +95,10 @@ public class ChallengeController {
     @DeleteMapping("/{challengeId}")
     public ApiUtil.ApiSuccessResult<String> deleteChallenge(@PathVariable Long challengeId,
                                   HttpServletRequest req) {
+
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
         Long memberId = (Long) req.getAttribute("memberId");
         Member member = memberService.getMemberById(memberId);
         challengeService.deleteChallenge(challengeId, member);

--- a/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
@@ -4,7 +4,11 @@ import com.greeny.ecomate.challenge.dto.ChallengeDto;
 import com.greeny.ecomate.challenge.dto.CreateChallengeRequestDto;
 import com.greeny.ecomate.challenge.entity.Challenge;
 import com.greeny.ecomate.challenge.service.ChallengeService;
+import com.greeny.ecomate.member.entity.Member;
+import com.greeny.ecomate.member.service.MemberService;
+import com.greeny.ecomate.security.provider.JwtProvider;
 import com.greeny.ecomate.utils.api.ApiUtil;
+import com.greeny.ecomate.utils.jwt.JwtExtractor;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +25,21 @@ import java.util.List;
 public class ChallengeController {
 
     private final ChallengeService challengeService;
+    private final MemberService memberService;
+    private final JwtProvider jwtProvider;
 
     @ApiResponse(description = "(관리자) 챌린지 생성")
     @PostMapping("/form")
-    public ApiUtil.ApiSuccessResult<Long> createNewChallenge(@Valid @RequestBody CreateChallengeRequestDto dto) {
-        return ApiUtil.success("챌린지 생성 성공", challengeService.createChallenge(dto));
+    public ApiUtil.ApiSuccessResult<Long> createNewChallenge(@Valid @RequestBody CreateChallengeRequestDto dto,
+                                                             HttpServletRequest req) {
+
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
+        Member member = memberService.getMemberById(memberId);
+        Long challengeId = challengeService.createChallenge(dto, member);
+        return ApiUtil.success("챌린지 생성 성공", challengeId);
     }
 
     @ApiResponse(description = "challengeId로 챌린지 단일 조회")
@@ -52,7 +66,9 @@ public class ChallengeController {
     public ApiUtil.ApiSuccessResult<Long> updateChallengeActiveYn(@PathVariable Long challengeId,
                                         @RequestBody boolean activeYn,
                                         HttpServletRequest req) {
-        challengeService.updateChallengeActiveYn(challengeId, activeYn);
+        Long memberId = (Long) req.getAttribute("memberId");
+        Member member = memberService.getMemberById(memberId);
+        challengeService.updateChallengeActiveYn(challengeId, activeYn, member);
         return ApiUtil.success("챌린지 활성화 여부 수정 성공", challengeId);
     }
 
@@ -61,8 +77,9 @@ public class ChallengeController {
     public ApiUtil.ApiSuccessResult<Long> updateChallenge(@PathVariable Long challengeId,
                                 @Valid @RequestBody ChallengeDto challengeDto,
                                 HttpServletRequest req) {
-
-        challengeService.updateChallenge(challengeId, challengeDto);
+        Long memberId = (Long) req.getAttribute("memberId");
+        Member member = memberService.getMemberById(memberId);
+        challengeService.updateChallenge(challengeId, challengeDto, member);
         return ApiUtil.success("챌린지 수정 성공", challengeId);
     }
 
@@ -70,7 +87,9 @@ public class ChallengeController {
     @DeleteMapping("/{challengeId}")
     public ApiUtil.ApiSuccessResult<String> deleteChallenge(@PathVariable Long challengeId,
                                   HttpServletRequest req) {
-        challengeService.deleteChallenge(challengeId);
+        Long memberId = (Long) req.getAttribute("memberId");
+        Member member = memberService.getMemberById(memberId);
+        challengeService.deleteChallenge(challengeId, member);
         return ApiUtil.success("챌린지 삭제 성공", "해당 챌린지가 삭제되었습니다.");
     }
 

--- a/src/main/java/com/greeny/ecomate/challenge/controller/MyChallengeController.java
+++ b/src/main/java/com/greeny/ecomate/challenge/controller/MyChallengeController.java
@@ -3,12 +3,17 @@ package com.greeny.ecomate.challenge.controller;
 import com.greeny.ecomate.challenge.dto.CreateMyChallengeRequestDto;
 import com.greeny.ecomate.challenge.dto.MyChallengeDto;
 import com.greeny.ecomate.challenge.service.MyChallengeService;
+import com.greeny.ecomate.member.entity.Member;
+import com.greeny.ecomate.member.service.MemberService;
+import com.greeny.ecomate.security.provider.JwtProvider;
 import com.greeny.ecomate.utils.api.ApiUtil;
+import com.greeny.ecomate.utils.jwt.JwtExtractor;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.List;
 
@@ -19,40 +24,69 @@ import java.util.List;
 public class MyChallengeController {
 
     private final MyChallengeService myChallengeService;
+    private final MemberService memberService;
+    private final JwtProvider jwtProvider;
 
     @ApiResponse(description = "챌린지 새도전 or 재도전")
-    @PostMapping("/form")
-    public ApiUtil.ApiSuccessResult<Long> createMyChallenge(@Valid @RequestBody CreateMyChallengeRequestDto dto) {
-        return ApiUtil.success("챌린지 도전 시작 성공", myChallengeService.createMyChallenge(dto));
+    @PostMapping("/{challengeId}")
+    public ApiUtil.ApiSuccessResult<Long> createMyChallenge(@PathVariable Long challengeId,
+                                                            HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
+        Long myChallengeId = myChallengeService.createMyChallenge(challengeId, memberId);
+        return ApiUtil.success("챌린지 도전 시작 성공", myChallengeId);
     }
 
     @ApiResponse(description = "memberId 별 도전 챌린지 전체 조회")
-    @GetMapping("/member/{memberId}")
-    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengeByMemberId(@PathVariable Long memberId) {
+    @GetMapping("/member/all")
+    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengeByMemberId(HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
+
         return ApiUtil.success("사용자별 도전 챌린지 조회 성공", myChallengeService.getAllMyChallengeByMemberId(memberId));
     }
 
     @ApiResponse(description = "memberId 별 진행 중인 챌린지 전체 조회")
-    @GetMapping("/member/{memberId}/proceeding")
-    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengeProceedingByMemberId(@PathVariable Long memberId) {
+    @GetMapping("/member/proceeding")
+    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengeProceedingByMemberId(HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
         return ApiUtil.success("사용자별 진행 중인 챌린지 전체 조회 성공", myChallengeService.getAllMyChallengeProceedingByMemberId(memberId));
     }
 
     @ApiResponse(description = "memberId 별 완료한 챌린지 전체 조회")
-    @GetMapping("/member/{memberId}/finish")
-    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengeDoneByMemberId(@PathVariable Long memberId) {
+    @GetMapping("/member/finish")
+    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengeDoneByMemberId(HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
         return ApiUtil.success("사용자별 완료한 챌린지 전체 조회 성공", myChallengeService.getAllMyChallengeFinishByMemberId(memberId));
     }
 
     @ApiResponse(description = "memberId에 해당하는 사용자가 진행 중인 챌린지 수 조회")
-    @GetMapping("/member/{memberId}/proceeding/cnt")
-    public ApiUtil.ApiSuccessResult<Long> getMyChallengeProceedingCntByMemberId(@PathVariable Long memberId) {
+    @GetMapping("/member/proceeding/cnt")
+    public ApiUtil.ApiSuccessResult<Long> getMyChallengeProceedingCntByMemberId(HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
         return ApiUtil.success("해당 사용자가 도전 중인 챌린지 수 조회 성공", myChallengeService.getMyChallengeProceedingCntByMemberId(memberId));
     }
 
     @ApiResponse(description = "memberId에 해당하는 사용자가 완료한 챌린지 수 조회")
-    @GetMapping("/member/{memberId}/finish/cnt")
-    public ApiUtil.ApiSuccessResult<Long> getMyChallengeDoneCntByMemberId(@PathVariable Long memberId) {
+    @GetMapping("/member/finish/cnt")
+    public ApiUtil.ApiSuccessResult<Long> getMyChallengeDoneCntByMemberId(HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
         return ApiUtil.success("해당 사용자가 도전 완료한 챌린지 수 조회 성공", myChallengeService.getMyChallengeFinishCntByMemberId(memberId));
     }
 
@@ -64,14 +98,25 @@ public class MyChallengeController {
 
     @ApiResponse(description = "myChallengeId로 해당 챌린지 도전에 대한 인증 횟수 수정")
     @PutMapping("/{myChallengeId}")
-    public ApiUtil.ApiSuccessResult<String> updateMyChallengeDoneCnt(@PathVariable Long myChallengeId) {
-        return ApiUtil.success("챌린지 도전에 대한 인증 횟수 수정 성공", myChallengeService.updateMyChallengeDoneCnt(myChallengeId));
+    public ApiUtil.ApiSuccessResult<String> updateMyChallengeDoneCnt(@PathVariable Long myChallengeId,
+                                                                     HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
+        String message = myChallengeService.updateMyChallengeDoneCnt(myChallengeId, memberId);
+        return ApiUtil.success("챌린지 도전에 대한 인증 횟수 수정 성공", message);
     }
 
     @ApiResponse(description = "myChallengeId로 해당 도전 챌린지 삭제 (포기)")
     @DeleteMapping("/{myChallengeId}")
-    public ApiUtil.ApiSuccessResult<String> deleteMyChallenge(@PathVariable Long myChallengeId) {
-        myChallengeService.deleteMyChallenge(myChallengeId);
+    public ApiUtil.ApiSuccessResult<String> deleteMyChallenge(@PathVariable Long myChallengeId,
+                                                              HttpServletRequest req) {
+        String memberToken = JwtExtractor.extractJwt(req);
+        req.setAttribute("memberId", jwtProvider.getMemberIdFromToken(memberToken));
+
+        Long memberId = (Long) req.getAttribute("memberId");
+        myChallengeService.deleteMyChallenge(myChallengeId, memberId);
         return ApiUtil.success("도전 챌린지 삭제 성공", "해당 챌린지를 포기하였습니다.");
     }
 

--- a/src/main/java/com/greeny/ecomate/challenge/repository/MyChallengeRepository.java
+++ b/src/main/java/com/greeny/ecomate/challenge/repository/MyChallengeRepository.java
@@ -11,13 +11,13 @@ import java.util.Optional;
 
 public interface MyChallengeRepository extends JpaRepository<MyChallenge, Long> {
 
-    List<MyChallenge> findAllByMember_MemberId(Long memberId);
+    Optional<List<MyChallenge>> findAllByMember_MemberId(Long memberId);
 
     Optional<MyChallenge> findMyChallengeByMember_MemberIdAndChallenge_ChallengeId(Long memberId, Long challengeId);
 
-    List<MyChallenge> findAllByMember_MemberIdAndAchieveType(Long memberId, AchieveType achieveType);
+    Optional<List<MyChallenge>> findAllByMember_MemberIdAndAchieveType(Long memberId, AchieveType achieveType);
 
-    Long countMyChallengesByMember_MemberIdAndAchieveType(Long memberId, AchieveType achieveType);
+    Optional<Long> countMyChallengesByMember_MemberIdAndAchieveType(Long memberId, AchieveType achieveType);
 
     @Query("SELECT mc from MyChallenge mc join fetch mc.member where mc.myChallengeId = :myChallengeId")
     Optional<MyChallenge> findMyChallengeByMyChallengeId(@Param(value = "myChallengeId") Long myChallengeId);

--- a/src/main/java/com/greeny/ecomate/challenge/service/ChallengeService.java
+++ b/src/main/java/com/greeny/ecomate/challenge/service/ChallengeService.java
@@ -7,6 +7,8 @@ import com.greeny.ecomate.challenge.entity.AchieveType;
 import com.greeny.ecomate.challenge.entity.Challenge;
 import com.greeny.ecomate.challenge.repository.ChallengeRepository;
 import com.greeny.ecomate.challenge.repository.MyChallengeRepository;
+import com.greeny.ecomate.member.entity.Member;
+import com.greeny.ecomate.member.entity.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +24,10 @@ public class ChallengeService {
     private final MyChallengeRepository myChallengeRepository;
 
     @Transactional
-    public Long createChallenge(CreateChallengeRequestDto dto) {
+    public Long createChallenge(CreateChallengeRequestDto dto, Member member) {
+        if(member.getRole() != Role.ROLE_ADMIN) {
+            throw new IllegalStateException("챌린지 생성 권한이 없습니다.");
+        }
         Challenge challenge = dto.toEntity();
         return challengeRepository.save(challenge).getChallengeId();
     }
@@ -43,7 +48,11 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void updateChallengeActiveYn(Long challengeId, boolean activeYn) {
+    public void updateChallengeActiveYn(Long challengeId, boolean activeYn, Member member) {
+        if(member.getRole() != Role.ROLE_ADMIN) {
+            throw new IllegalStateException("챌린지 활성화 수정 권한이 없습니다.");
+        }
+
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new IllegalArgumentException("챌린지가 존재하지 않습니다."));
 
@@ -51,7 +60,11 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void updateChallenge(Long challengeId, ChallengeDto challengeDto) {
+    public void updateChallenge(Long challengeId, ChallengeDto challengeDto, Member member) {
+        if(member.getRole() != Role.ROLE_ADMIN) {
+            throw new IllegalStateException("챌린지 내용 수정 권한이 없습니다.");
+        }
+
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new IllegalArgumentException("챌린지가 존재하지 않습니다."));
 
@@ -62,7 +75,11 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void deleteChallenge(Long challengeId) {
+    public void deleteChallenge(Long challengeId, Member member) {
+        if(member.getRole() != Role.ROLE_ADMIN) {
+            throw new IllegalStateException("챌린지 삭제 권한이 없습니다.");
+        }
+
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new IllegalArgumentException("챌린지가 존재하지 않습니다."));
         challengeRepository.delete(challenge);

--- a/src/main/java/com/greeny/ecomate/config/SecurityConfig.java
+++ b/src/main/java/com/greeny/ecomate/config/SecurityConfig.java
@@ -33,25 +33,14 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain accountFilterChain(HttpSecurity http,
+    public SecurityFilterChain memberFilterChain(HttpSecurity http,
                                                   JwtProvider jwtProvider, ObjectMapper objectMapper) throws Exception {
         return setJwtHttpSecurity(http, objectMapper)
                 .requestMatchers()
-                .antMatchers("/api/v1/admin/**")
-                .antMatchers("/api/v1/auth/members/login")
-                .antMatchers("/api/v1/auth/members/new")
-                .antMatchers(HttpMethod.GET, "/api/v1/challenges/**")
-                .antMatchers(HttpMethod.GET,"/api/v1/communities/{id}")
-                .antMatchers(HttpMethod.GET,"/api/v1/boards/**")
-                .antMatchers(HttpMethod.GET,"/api/v1/comments/boards/**")
+                .antMatchers("/api/v1/**")
                 .and()
                 .authorizeRequests()
-                .antMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                .antMatchers("/api/v1/auth/members/**").hasAnyRole("USER", "ADMIN")
-                .antMatchers("/api/v1/challenges/**").hasAnyRole("USER", "ADMIN")
-                .antMatchers("/api/v1/myChallenges/**").hasAnyRole("USER", "ADMIN")
-                .antMatchers("/api/v1/boards/**").hasAnyRole("USER", "ADMIN")
-                .antMatchers("/api/v1/members/**").hasAnyRole("USER", "ADMIN")
+                .antMatchers("/api/v1/**").hasAnyRole("ROLE_USER", "ROLE_ADMIN")
                 .and()
                 .addFilterAfter(jwtAuthenticationFilter(jwtProvider),
                         JwtExceptionFilter.class)
@@ -65,7 +54,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .antMatchers(HttpMethod.OPTIONS, "/api/v1/**").permitAll()
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(new JwtNotAuthenticatedHandler(new ObjectMapper()))

--- a/src/main/java/com/greeny/ecomate/config/WebConfig.java
+++ b/src/main/java/com/greeny/ecomate/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.greeny.ecomate.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/v1/**")
+                .allowedOrigins("https://localhost:3000")
+                .allowedMethods("GET", "POST", "DELETE", "PUT", "OPTIONS")
+                .allowedHeaders("*")
+                .exposedHeaders("*")
+                .allowCredentials(true);
+    }
+
+}

--- a/src/main/java/com/greeny/ecomate/member/repository/MemberRepository.java
+++ b/src/main/java/com/greeny/ecomate/member/repository/MemberRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByMemberId(Long member);
+
     Optional<Member> findByNickname(String nickname);
 
     Optional<Member> findByName(String name);

--- a/src/main/java/com/greeny/ecomate/member/service/MemberService.java
+++ b/src/main/java/com/greeny/ecomate/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.greeny.ecomate.member.service;
 
+import com.greeny.ecomate.exception.NotFoundException;
 import com.greeny.ecomate.member.dto.CreateMemberRequestDto;
 import com.greeny.ecomate.member.dto.MemberDto;
 import com.greeny.ecomate.member.entity.Member;
@@ -22,6 +23,11 @@ public class MemberService {
     public List<MemberDto> getAllMember() {
         List<Member> memberList = memberRepository.findAll();
         return memberList.stream().map(MemberDto::from).toList();
+    }
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
     }
 
 }

--- a/src/main/java/com/greeny/ecomate/security/detail/MemberDetailsService.java
+++ b/src/main/java/com/greeny/ecomate/security/detail/MemberDetailsService.java
@@ -15,9 +15,9 @@ public class MemberDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일과 일치하는 계정이 없습니다."));
+    public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
+        Member member = memberRepository.findByMemberId(Long.parseLong(memberId))
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자 입니다."));
 
         return new MemberDetails(member);
     }

--- a/src/main/java/com/greeny/ecomate/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/greeny/ecomate/security/filter/JwtAuthenticationFilter.java
@@ -3,11 +3,13 @@ package com.greeny.ecomate.security.filter;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.greeny.ecomate.exception.TokenNotFoundException;
 import com.greeny.ecomate.security.provider.JwtProvider;
+import com.greeny.ecomate.utils.cookie.CookieUtil;
 import com.greeny.ecomate.utils.jwt.JwtExtractor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
 import javax.servlet.FilterChain;
@@ -26,7 +28,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
     throws IOException, ServletException, TokenNotFoundException, JWTVerificationException {
 
-        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletRequest req = (HttpServletRequest)request;
 
         if(req.getMethod().equals("OPTIONS")) {
             chain.doFilter(request, response);
@@ -41,7 +43,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         request.setAttribute("memberId", memberId);
         request.setAttribute("email", email);
 
-        Authentication authenticate = jwtProvider.authenticate(new UsernamePasswordAuthenticationToken(email, " "));
+        Authentication authenticate = jwtProvider.authenticate(new UsernamePasswordAuthenticationToken(email, memberId));
         SecurityContextHolder.getContext().setAuthentication(authenticate);
 
         chain.doFilter(request, response);


### PR DESCRIPTION
resolve #49 

사용자 인증 기능이 추가됨에 따라, 챌린지 관련 기능을 수정하였습니다.

**변경 사항**
* 관리자만 챌린지를 생성, 수정, 삭제할 수 있도록 수정
* 로그인된 사용자가 본인의 챌린지만 도전, 조회, 수정, 삭제할 수 있도록 수정
* api url의 memberId PathVariable 삭제
