### PR TITLE
redis host 값 파일 위치 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,6 @@ spring:
       order: 2
 
   redis:
-    host: 127.0.0.1
     port: 6379
 
   jpa:


### PR DESCRIPTION
resolve #56 

### 수정 사항
- docker 환경 내에서 redis 구동 시 redis connection 오류 -> redis host 값을 application-secret.yaml 파일로 이동
   - docker에서 redis 구동 시에 host는 docker container 이름으로 설정됨. 따라서, host 이름을  application-secret.yaml 파일로 이동시키고 실행 환경에 맞게 변경