### PR TITLE
댓글 생성 시에 사용자 정보 제거, 댓글 조회에 필요한 정보 추가

### DIFF
--- a/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
+++ b/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.greeny.ecomate.comment.service.CommentService;
 import com.greeny.ecomate.posting.dto.BoardDto;
 import com.greeny.ecomate.posting.entity.Board;
 import com.greeny.ecomate.utils.api.ApiUtil;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +23,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
+    @Operation(summary = "댓글 생성")
     public ApiUtil.ApiSuccessResult<Long> createComment(@Valid @RequestBody CreateCommentRequestDto createRequest,
                                                         HttpServletRequest req) {
         Long memberId = (Long) req.getAttribute("memberId");
@@ -29,11 +31,13 @@ public class CommentController {
     }
 
     @GetMapping("/boards/{boardId}")
+    @Operation(summary = "특정 게시물의 댓글 조회")
     public ApiUtil.ApiSuccessResult<CommentListDto> getCommentByBoard(@PathVariable Long boardId) {
         return ApiUtil.success("게시물의 댓글 조회 성공", commentService.getCommentByBoard(boardId));
     }
 
     @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글 삭제")
     public ApiUtil.ApiSuccessResult<String> deleteCommentById(@PathVariable Long commentId,
                                                               HttpServletRequest req) {
         Long memberId = (Long) req.getAttribute("memberId");

--- a/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
+++ b/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
@@ -22,8 +22,10 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    public ApiUtil.ApiSuccessResult<Long> createComment(@Valid  @RequestBody CreateCommentRequestDto createRequest) {
-        return ApiUtil.success("댓글 생성 성공", commentService.createComment(createRequest));
+    public ApiUtil.ApiSuccessResult<Long> createComment(@Valid @RequestBody CreateCommentRequestDto createRequest,
+                                                        HttpServletRequest req) {
+        Long memberId = (Long) req.getAttribute("memberId");
+        return ApiUtil.success("댓글 생성 성공", commentService.createComment(createRequest, memberId));
     }
 
     @GetMapping("/boards/{boardId}")

--- a/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
+++ b/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
@@ -30,7 +30,7 @@ public class CommentController {
         return ApiUtil.success("댓글 생성 성공", commentService.createComment(createRequest, memberId));
     }
 
-    @GetMapping("/boards/{boardId}")
+    @GetMapping("/board/{boardId}")
     @Operation(summary = "특정 게시물의 댓글 조회")
     public ApiUtil.ApiSuccessResult<CommentListDto> getCommentByBoard(@PathVariable Long boardId) {
         return ApiUtil.success("게시물의 댓글 조회 성공", commentService.getCommentByBoard(boardId));

--- a/src/main/java/com/greeny/ecomate/comment/dto/CommentDto.java
+++ b/src/main/java/com/greeny/ecomate/comment/dto/CommentDto.java
@@ -1,14 +1,29 @@
 package com.greeny.ecomate.comment.dto;
 
+import com.greeny.ecomate.comment.entity.Comment;
+import com.greeny.ecomate.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
-@AllArgsConstructor
 public class CommentDto {
 
     private Long commentId;
+    private Long memberId;
     private String nickname;
+    private String profileImage;
     private String content;
+    private LocalDateTime createdDate;
+
+    public CommentDto(Member member, Comment comment) {
+        this.commentId = comment.getCommentId();
+        this.memberId = member.getMemberId();
+        this.nickname = member.getNickname();
+        this.profileImage = member.getProfileImage();
+        this.content = comment.getContent();
+        this.createdDate = comment.getCreatedDate();
+    }
 
 }

--- a/src/main/java/com/greeny/ecomate/comment/dto/CreateCommentRequestDto.java
+++ b/src/main/java/com/greeny/ecomate/comment/dto/CreateCommentRequestDto.java
@@ -10,8 +10,5 @@ public class CreateCommentRequestDto {
     private Long boardId;
 
     @NotNull
-    private String nickname;
-
-    @NotNull
     private String content;
 }

--- a/src/main/java/com/greeny/ecomate/comment/service/CommentService.java
+++ b/src/main/java/com/greeny/ecomate/comment/service/CommentService.java
@@ -11,6 +11,7 @@ import com.greeny.ecomate.posting.repository.BoardRepository;
 import com.greeny.ecomate.member.entity.Member;
 import com.greeny.ecomate.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentService {
+
+    @Value("${s3-directory.profile}")
+    String profileDirectory;
+
+    @Value("${cloud.aws.s3.url}")
+    String s3Url;
 
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
@@ -55,7 +62,7 @@ public class CommentService {
         Member member = memberRepository.findById(comment.getMemberId())
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
 
-        return new CommentDto(comment.getCommentId(), member.getNickname(), comment.getContent());
+        return new CommentDto(member, comment);
     }
 
     public void deleteCommentById(Long commentId, Long memberId) {

--- a/src/main/java/com/greeny/ecomate/comment/service/CommentService.java
+++ b/src/main/java/com/greeny/ecomate/comment/service/CommentService.java
@@ -28,8 +28,8 @@ public class CommentService {
     private final BoardRepository boardRepository;
 
     @Transactional
-    public Long createComment(CreateCommentRequestDto createRequest) {
-        Member member = memberRepository.findByNickname(createRequest.getNickname())
+    public Long createComment(CreateCommentRequestDto createRequest, Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
 
         Board board = boardRepository.findById(createRequest.getBoardId())


### PR DESCRIPTION
resolve #73 

### 수정 사항
- 댓글 생성 로직에서 사용자 정보를 포함해서 요청 -> 토큰으로 사용자 식별하는 것으로 변경
- 댓글 조회 시에 사용자 정보, 작성 시간 정보 추가