### PR TITLE
Fix: 특정 게시물의 댓글 조회 uri 복구

### DIFF
--- a/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
+++ b/src/main/java/com/greeny/ecomate/comment/controller/CommentController.java
@@ -30,7 +30,7 @@ public class CommentController {
         return ApiUtil.success("댓글 생성 성공", commentService.createComment(createRequest, memberId));
     }
 
-    @GetMapping("/board/{boardId}")
+    @GetMapping("/boards/{boardId}")
     @Operation(summary = "특정 게시물의 댓글 조회")
     public ApiUtil.ApiSuccessResult<CommentListDto> getCommentByBoard(@PathVariable Long boardId) {
         return ApiUtil.success("게시물의 댓글 조회 성공", commentService.getCommentByBoard(boardId));


### PR DESCRIPTION
#73 

### 수정 사항
- 특정 댓글 조회 uri를 복수형 boards 로 통일