### PR TITLE
권한에 따른 챌린지 리스트 조회 기능 추가

### DIFF
--- a/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
@@ -47,11 +47,13 @@ public class ChallengeController {
         return ApiUtil.success("챌린지 조회 성공", challengeService.getChallengeById(challengeId));
     }
 
-    @Operation(summary = "챌린지 전체 조회")
+    @Operation(summary = "챌린지 전체 조회", description = "account token이 필요합니다.")
     @ApiResponse(description = "챌린지 전체 조회")
     @GetMapping
-    public ApiUtil.ApiSuccessResult<List<ChallengeDto>> getAllChallenge() {
-        return ApiUtil.success("챌린지 전체 조회 성공", challengeService.findAllChallenge());
+    public ApiUtil.ApiSuccessResult<List<ChallengeDto>> getAllChallenge(HttpServletRequest req) {
+        Long memberId = (Long) req.getAttribute("memberId");
+        Member member = memberService.getMemberById(memberId);
+        return ApiUtil.success("챌린지 전체 조회 성공", challengeService.findAllChallenge(member));
     }
 
     @Operation(summary = "로그인된 사용자가 도전하지 않은 챌린지 전체 조회")

--- a/src/main/java/com/greeny/ecomate/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/greeny/ecomate/challenge/repository/ChallengeRepository.java
@@ -2,9 +2,11 @@ package com.greeny.ecomate.challenge.repository;
 
 import com.greeny.ecomate.challenge.entity.Challenge;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+import java.util.List;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+    List<Challenge> findChallengesByActiveYn(Boolean activeYn);
 
 }

--- a/src/main/java/com/greeny/ecomate/challenge/service/ChallengeService.java
+++ b/src/main/java/com/greeny/ecomate/challenge/service/ChallengeService.java
@@ -11,6 +11,7 @@ import com.greeny.ecomate.challenge.repository.ChallengeRepository;
 import com.greeny.ecomate.challenge.repository.MyChallengeRepository;
 import com.greeny.ecomate.member.entity.Member;
 import com.greeny.ecomate.member.entity.Role;
+import com.greeny.ecomate.member.repository.MemberRepository;
 import com.greeny.ecomate.s3.service.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -75,8 +76,12 @@ public class ChallengeService {
         return new ChallengeDto(challenge, s3Url, challengeDirectory);
     }
 
-    public List<ChallengeDto> findAllChallenge() {
-        List<Challenge> challengeList = challengeRepository.findAll();
+    public List<ChallengeDto> findAllChallenge(Member member) {
+        List<Challenge> challengeList;
+        if(member.getRole() != Role.ROLE_ADMIN)
+            challengeList = challengeRepository.findChallengesByActiveYn(true);
+        else
+            challengeList = challengeRepository.findAll();
         return challengeList.stream().map(this::createChallengeDto).toList();
     }
 

--- a/src/main/java/com/greeny/ecomate/member/repository/MemberRepository.java
+++ b/src/main/java/com/greeny/ecomate/member/repository/MemberRepository.java
@@ -16,7 +16,7 @@ public interface MemberRepository extends
         QuerydslPredicateExecutor<Member>,
         QuerydslBinderCustomizer<QMember> {
 
-    Optional<Member> findByMemberId(Long member);
+    Optional<Member> findByMemberId(Long memberId);
 
     Optional<Member> findByNickname(String nickname);
 


### PR DESCRIPTION
resolve #110 

**변경 사항**
* 전체 챌린지 리스트 조회 기능을 로그인된 사용자의 권한에 따라 활성화 여부에 의해 필터링하여 조회할 수 있도록 변경
  * 관리자 - 활성화 된 챌린지 리스트와 활성화 되지 않은 챌린지 리스트 전체 조회 
  * 일반 사용자 - 활성화 된 챌린지 리스트 전체 조회
 