### PR TITLE
달성하지 않은 챌린지 조회 기능 수정

### DIFF
--- a/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/greeny/ecomate/challenge/controller/ChallengeController.java
@@ -47,7 +47,7 @@ public class ChallengeController {
         return ApiUtil.success("챌린지 조회 성공", challengeService.getChallengeById(challengeId));
     }
 
-    @Operation(summary = "챌린지 전체 조회", description = "account token이 필요합니다.")
+    @Operation(summary = "챌린지 전체 조회", description = "account token이 필요합니다. 권한에 따라 활성화 여부에 의해 필터링된 챌린지 리스트를 조회할 수 있습니다.")
     @ApiResponse(description = "챌린지 전체 조회")
     @GetMapping
     public ApiUtil.ApiSuccessResult<List<ChallengeDto>> getAllChallenge(HttpServletRequest req) {
@@ -56,12 +56,13 @@ public class ChallengeController {
         return ApiUtil.success("챌린지 전체 조회 성공", challengeService.findAllChallenge(member));
     }
 
-    @Operation(summary = "로그인된 사용자가 도전하지 않은 챌린지 전체 조회")
+    @Operation(summary = "로그인된 사용자가 도전하지 않은 챌린지 전체 조회", description = "account token이 필요합니다.")
     @ApiResponse(description = "로그인된 사용자가 도전하지 않은 챌린지 전체 조회")
     @GetMapping("/unchallenged")
     public ApiUtil.ApiSuccessResult<List<ChallengeDto>> getBeforeStartChallenges(HttpServletRequest req) {
         Long memberId = (Long) req.getAttribute("memberId");
-        return ApiUtil.success("도전하지 않은 챌린지 전체 조회 성공", challengeService.findBeforeStartChallenge(memberId));
+        Member member = memberService.getMemberById(memberId);
+        return ApiUtil.success("도전하지 않은 챌린지 전체 조회 성공", challengeService.findBeforeStartChallenge(member));
     }
 
     @Operation(summary = "challengeId로 해당 챌린지를 도전하고 있는 회원 수 조회")

--- a/src/main/java/com/greeny/ecomate/challenge/service/ChallengeService.java
+++ b/src/main/java/com/greeny/ecomate/challenge/service/ChallengeService.java
@@ -34,6 +34,7 @@ public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
     private final MyChallengeRepository myChallengeRepository;
+    private final MemberRepository memberRepository;
 
     private final AwsS3Service awsS3Service;
     private final MyChallengeService myChallengeService;
@@ -85,9 +86,14 @@ public class ChallengeService {
         return challengeList.stream().map(this::createChallengeDto).toList();
     }
 
-    public List<ChallengeDto> findBeforeStartChallenge(Long memberId) {
-        List<Long> afterStartChallengeList = myChallengeService.getAllMyChallengeByMemberId(memberId).stream().map(MyChallengeDto::getChallengeId).toList();
-        List<Challenge> beforeStartChallengeList = challengeRepository.findAll();
+    public List<ChallengeDto> findBeforeStartChallenge(Member member) {
+        List<Long> afterStartChallengeList = myChallengeService.getAllMyChallengeByMemberId(member.getMemberId()).stream().map(MyChallengeDto::getChallengeId).toList();
+        List<Challenge> beforeStartChallengeList;
+        if(member.getRole() != Role.ROLE_ADMIN)
+            beforeStartChallengeList = challengeRepository.findChallengesByActiveYn(true);
+        else
+            beforeStartChallengeList = challengeRepository.findAll();
+
         for (Long idx : afterStartChallengeList) {
             Challenge challenge = findChallengeById(idx);
             beforeStartChallengeList.remove(challenge);


### PR DESCRIPTION
resolve #114 

변경 사항
* 로그인된 사용자가 달성하지 않은 챌린지를 조회할 때 활성화 되지 않은 챌린지를 제외하여 조회할 수 있도록 관련 api를 수정
* 로그인된 사용자가 관리자일 경우 활성화 여부에 상관없이 전체 챌린지를 조회할 수 있도록 수정