### PR TITLE
특정 사용자의 도전 진행 중이거나 완료한 챌린지 리스트 조회 기능 추가

### DIFF
--- a/src/main/java/com/greeny/ecomate/challenge/controller/MyChallengeController.java
+++ b/src/main/java/com/greeny/ecomate/challenge/controller/MyChallengeController.java
@@ -73,8 +73,15 @@ public class MyChallengeController {
     @Operation(summary = "memberId에 해당하는 사용자의 진행 중인 챌린지 전체 조회")
     @ApiResponse(description = "memberId에 해당하는 사용자의 진행 중인 챌린지 전체 조회")
     @GetMapping("/member/{memberId}/proceeding")
-    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengeProceedingByMemberId(@PathVariable Long memberId) {
+    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengesProceedingByMemberId(@PathVariable Long memberId) {
         return ApiUtil.success("해당 사용자의 진행 중인 챌린지 전제 조회 성공", myChallengeService.getAllMyChallengeProceedingByMemberId(memberId));
+    }
+
+    @Operation(summary = "memberId에 해당하는 사용자의 진행 중이거나 완료한 챌린지 전체 조회")
+    @ApiResponse(description = "memberId에 해당하는 사용자의 진행 중이거나 완료한 챌린지 전체 조회")
+    @GetMapping("/member/{memberId}/all")
+    public ApiUtil.ApiSuccessResult<List<MyChallengeDto>> getAllMyChallengesByMemberId(@PathVariable Long memberId) {
+        return ApiUtil.success("해당 사용자의 진행 중이거나 완료한 챌린지 전체 조회 성공", myChallengeService.getAllMyChallengeByMemberId(memberId));
     }
 
     @Operation(summary = "myChallengeId로 도전 챌린지 단일 조회")


### PR DESCRIPTION
resolve #122 

**추가 사항**
* memberId에 해당하는 특정 사용자의 도전 진행 중이거나 완료한 챌린지 리스트를 조회하는 기능 추가
