### PR TITLE
챌린지 등록 게시물과 챌린지 달성 횟수 연동

### DIFF
--- a/src/main/java/com/greeny/ecomate/challenge/controller/MyChallengeController.java
+++ b/src/main/java/com/greeny/ecomate/challenge/controller/MyChallengeController.java
@@ -84,13 +84,13 @@ public class MyChallengeController {
         return ApiUtil.success("도전 챌린지 단일 조회 성공", myChallengeService.getMyChallengeById(myChallengeId));
     }
 
-    @Operation(summary = "myChallengeId로 해당 챌린지 도전에 대한 인증 횟수 수정", description = "account token이 필요합니다.")
-    @ApiResponse(description = "myChallengeId로 해당 챌린지 도전에 대한 인증 횟수 수정")
-    @PutMapping("/{myChallengeId}")
-    public ApiUtil.ApiSuccessResult<String> updateMyChallengeDoneCnt(@PathVariable Long myChallengeId,
+    @Operation(summary = "challengeId로 해당 챌린지 도전에 대한 인증 횟수 수정", description = "account token이 필요합니다.")
+    @ApiResponse(description = "challengeId로 해당 챌린지 도전에 대한 인증 횟수 수정")
+    @PutMapping("/{challengeId}")
+    public ApiUtil.ApiSuccessResult<String> updateMyChallengeDoneCnt(@PathVariable Long challengeId,
                                                                      HttpServletRequest req) {
         Long memberId = (Long) req.getAttribute("memberId");
-        String message = myChallengeService.updateMyChallengeDoneCnt(myChallengeId, memberId);
+        String message = myChallengeService.updateMyChallengeDoneCnt(challengeId, memberId);
         return ApiUtil.success("챌린지 도전에 대한 인증 횟수 수정 성공", message);
     }
 

--- a/src/main/java/com/greeny/ecomate/challenge/repository/MyChallengeRepository.java
+++ b/src/main/java/com/greeny/ecomate/challenge/repository/MyChallengeRepository.java
@@ -24,4 +24,6 @@ public interface MyChallengeRepository extends JpaRepository<MyChallenge, Long> 
 
     Long countMyChallengesByChallenge_ChallengeIdAndAchieveType(Long challengeId, AchieveType achieveType);
 
+    @Query("SELECT mc FROM MyChallenge mc join fetch mc.member where mc.challenge.challengeId = :challengeId and mc.member.memberId = :memberId and mc.achieveType = :achieveType")
+    Optional<MyChallenge> findByChallengeIdAndMemberIdAndAchieveType(Long challengeId, Long memberId, AchieveType achieveType);
 }


### PR DESCRIPTION
resolve #119 

### 수정 사항
- 챌린지를 등록한 게시물을 생성할 때 챌린지 달성 횟수를 증가시키는 로직 추가