### PR TITLE
채팅방 내 멤버들의 챌린지 현황 조회 기능 추가

### DIFF
--- a/src/main/java/com/greeny/ecomate/board/dto/BoardDto.java
+++ b/src/main/java/com/greeny/ecomate/board/dto/BoardDto.java
@@ -1,6 +1,7 @@
 package com.greeny.ecomate.board.dto;
 
 import com.greeny.ecomate.board.entity.Board;
+import com.greeny.ecomate.utils.imageUtil.ImageUtil;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -20,17 +21,15 @@ public class BoardDto {
     private Boolean liked;
     private LocalDateTime createdDate;
 
-    public BoardDto(Board board, String challengeTitle, String imageUrl, String profileImageUrl, Boolean liked) {
+    public BoardDto(Board board, String challengeTitle, Boolean liked) {
         this.boardId = board.getBoardId();
         this.memberId = board.getMember().getMemberId();
         this.nickname = board.getMember().getNickname();
-        if (board.getMember().getProfileImage() != null) {
-            this.profileImage = profileImageUrl + "/" + board.getMember().getProfileImage();
-        }
+        this.profileImage = ImageUtil.getProfileImage(board.getMember().getProfileImage());
         this.challengeTitle = challengeTitle;
         this.boardTitle = board.getBoardTitle();
         this.boardContent = board.getBoardContent();
-        this.image = imageUrl + "/" + board.getImage();
+        this.image = ImageUtil.getBoardImage(board.getImage());
         this.likeCnt = board.getLikeCnt();
         this.liked = liked;
         this.createdDate = board.getCreatedDate();

--- a/src/main/java/com/greeny/ecomate/board/service/BoardService.java
+++ b/src/main/java/com/greeny/ecomate/board/service/BoardService.java
@@ -15,6 +15,7 @@ import com.greeny.ecomate.like.repository.LikeRepository;
 import com.greeny.ecomate.s3.service.AwsS3Service;
 import com.greeny.ecomate.member.entity.Member;
 import com.greeny.ecomate.member.repository.MemberRepository;
+import com.greeny.ecomate.utils.imageUtil.ImageUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
@@ -47,6 +48,7 @@ public class BoardService {
 
    private final AwsS3Service awsS3Service;
    private final MyChallengeService myChallengeService;
+   private final ImageUtil imageUtil;
 
    @Transactional
    public Board createBoard(CreateBoardRequestDto createDto, MultipartFile file, Long memberId) {
@@ -126,17 +128,15 @@ public class BoardService {
    }
 
    private BoardDto createBoardDto(Board board, Long memberId) {
-      String imageUrl = s3Url + "/" + boardDirectory;
-      String profileImageUrl = s3Url + "/" + profileImageDirectory;
       Boolean liked = likeRepository.findByBoardAndMemberId(board, memberId).isPresent();
 
       Long challengeId = board.getChallengeId();
       if (challengeId != 0) {
          Challenge challenge = challengeRepository.findById(challengeId)
                  .orElseThrow(() -> new NotFoundException("존재하지 않는 챌린지입니다."));
-         return new BoardDto(board, challenge.getChallengeTitle(), imageUrl, profileImageUrl, liked);
+         return new BoardDto(board, challenge.getChallengeTitle(), liked);
       }
-      return new BoardDto(board, null, imageUrl, profileImageUrl, liked);
+      return new BoardDto(board, null, liked);
    }
 
     private Board findBoardById(Long boardId) {

--- a/src/main/java/com/greeny/ecomate/challenge/repository/MyChallengeRepository.java
+++ b/src/main/java/com/greeny/ecomate/challenge/repository/MyChallengeRepository.java
@@ -2,6 +2,7 @@ package com.greeny.ecomate.challenge.repository;
 
 import com.greeny.ecomate.challenge.entity.AchieveType;
 import com.greeny.ecomate.challenge.entity.MyChallenge;
+import com.greeny.ecomate.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +27,6 @@ public interface MyChallengeRepository extends JpaRepository<MyChallenge, Long> 
 
     @Query("SELECT mc FROM MyChallenge mc join fetch mc.member where mc.challenge.challengeId = :challengeId and mc.member.memberId = :memberId and mc.achieveType = :achieveType")
     Optional<MyChallenge> findByChallengeIdAndMemberIdAndAchieveType(Long challengeId, Long memberId, AchieveType achieveType);
+
+    List<MyChallenge> findAllByMember(Member member);
 }

--- a/src/main/java/com/greeny/ecomate/utils/imageUtil/ImageUtil.java
+++ b/src/main/java/com/greeny/ecomate/utils/imageUtil/ImageUtil.java
@@ -1,0 +1,36 @@
+package com.greeny.ecomate.utils.imageUtil;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageUtil {
+
+    private static final String boardImageDirectory = "board";
+
+    private static final String profileImageDirectory = "profile";
+
+    private static final String challengeImageDirectory = "challenge";
+
+    private static final String s3Url = "https://ecomate-s3.s3.ap-northeast-2.amazonaws.com";
+
+    public static String getProfileImage(String imageName) {
+        return getImage(profileImageDirectory, imageName);
+    }
+
+    public static String getBoardImage(String imageName) {
+        return getImage(boardImageDirectory, imageName);
+    }
+
+    public static String getChallengeImage(String imageName) {
+        return getImage(challengeImageDirectory, imageName);
+    }
+
+    private static String getImage(String directory, String imageName) {
+        if (imageName == null) {
+            return null;
+        }
+        return s3Url + "/" + directory + "/" + imageName;
+    }
+
+}

--- a/src/main/java/com/greeny/ecomate/websocket/controller/ChatRoomController.java
+++ b/src/main/java/com/greeny/ecomate/websocket/controller/ChatRoomController.java
@@ -1,10 +1,7 @@
 package com.greeny.ecomate.websocket.controller;
 
 import com.greeny.ecomate.utils.api.ApiUtil;
-import com.greeny.ecomate.websocket.dto.ChatRoomResponseDto;
-import com.greeny.ecomate.websocket.dto.CreateChatRoomRequestDto;
-import com.greeny.ecomate.websocket.dto.MemberToChatRoomDto;
-import com.greeny.ecomate.websocket.dto.UpdateChatRoomRequestDto;
+import com.greeny.ecomate.websocket.dto.*;
 import com.greeny.ecomate.websocket.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,6 +35,14 @@ public class ChatRoomController {
     public ApiUtil.ApiSuccessResult<List<ChatRoomResponseDto>> rooms(HttpServletRequest req) {
         Long memberId = (Long) req.getAttribute("memberId");
         return ApiUtil.success("채팅방 리스트 조회 성공", chatRoomService.findAllRoomByMemberId(memberId));
+    }
+
+    @Operation(summary = "채팅방 내 멤버들의 챌린지 현황 조회")
+    @GetMapping("/{roomId}")
+    public ApiUtil.ApiSuccessResult<ChallengeStatusListDto> getChallengeStatusByChatRoom(@PathVariable Long roomId,
+                                                                                         HttpServletRequest req) {
+        Long memberId = (Long) req.getAttribute("memberId");
+        return ApiUtil.success("채팅방 멤버들의 챌린지 현황 조회 성공", new ChallengeStatusListDto(chatRoomService.getChallengeStatusByChatRoom(roomId, memberId)));
     }
 
     @Operation(summary = "채팅방 멤버 초대 시 멤버 닉네임 검색", description = "account token이 필요합니다.")

--- a/src/main/java/com/greeny/ecomate/websocket/dto/ChallengeStatusDto.java
+++ b/src/main/java/com/greeny/ecomate/websocket/dto/ChallengeStatusDto.java
@@ -1,0 +1,13 @@
+package com.greeny.ecomate.websocket.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChallengeStatusDto {
+    private String nickname;
+    private String profileImage;
+    private Long challengeDoneCnt;
+
+}

--- a/src/main/java/com/greeny/ecomate/websocket/dto/ChallengeStatusDto.java
+++ b/src/main/java/com/greeny/ecomate/websocket/dto/ChallengeStatusDto.java
@@ -1,5 +1,7 @@
 package com.greeny.ecomate.websocket.dto;
 
+import com.greeny.ecomate.member.entity.Member;
+import com.greeny.ecomate.utils.imageUtil.ImageUtil;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,5 +11,11 @@ public class ChallengeStatusDto {
     private String nickname;
     private String profileImage;
     private Long challengeDoneCnt;
+
+    public ChallengeStatusDto(Member member, Long challengeDoneCnt) {
+        this.nickname = member.getNickname();
+        this.profileImage = ImageUtil.getProfileImage(member.getProfileImage());
+        this.challengeDoneCnt = challengeDoneCnt;
+    }
 
 }

--- a/src/main/java/com/greeny/ecomate/websocket/dto/ChallengeStatusListDto.java
+++ b/src/main/java/com/greeny/ecomate/websocket/dto/ChallengeStatusListDto.java
@@ -1,0 +1,12 @@
+package com.greeny.ecomate.websocket.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ChallengeStatusListDto {
+    List<ChallengeStatusDto> challengeStatusList;
+}

--- a/src/main/java/com/greeny/ecomate/websocket/repository/ChatJoinRepository.java
+++ b/src/main/java/com/greeny/ecomate/websocket/repository/ChatJoinRepository.java
@@ -19,4 +19,10 @@ public interface ChatJoinRepository extends JpaRepository<ChatJoin, Long> {
     @Query("SELECT cj FROM ChatJoin cj where cj.chatRoom.roomId = :chatRoomId and cj.member.memberId = :memberId")
     Optional<ChatJoin> findChatJoinByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);
 
+    @Query("SELECT cj FROM ChatJoin cj join fetch cj.member where cj.chatRoom.roomId = :chatRoomId")
+    List<ChatJoin> findChatJoinsByChatRoomId(Long chatRoomId);
+
+    @Query("SELECT cj FROM ChatJoin cj where cj.chatRoom.roomId = :roomId and cj.member.memberId = :memberId")
+    Optional<ChatJoin> findChatJoinByRoomIdAndMemberId(Long roomId, Long memberId);
+
 }

--- a/src/main/java/com/greeny/ecomate/websocket/service/ChatRoomService.java
+++ b/src/main/java/com/greeny/ecomate/websocket/service/ChatRoomService.java
@@ -32,8 +32,6 @@ public class ChatRoomService {
     private final MyChallengeRepository myChallengeRepository;
     private final MemberRepository memberRepository;
 
-    private final ImageUtil imageUtil;
-
     @Transactional
     public Long createRoom(CreateChatRoomRequestDto dto, Long memberId) {
         ChatRoom chatRoom = ChatRoom.builder()
@@ -76,8 +74,7 @@ public class ChatRoomService {
 
         return memberList.stream().map(member ->
             new ChallengeStatusDto(
-                  member.getNickname(),
-                  imageUtil.getProfileImage(member.getProfileImage()),
+                  member,
                   myChallengeRepository.findAllByMember(member)
                           .stream().mapToLong(this::getTotalDoneCnt).sum()
             )

--- a/src/main/java/com/greeny/ecomate/websocket/service/ChatRoomService.java
+++ b/src/main/java/com/greeny/ecomate/websocket/service/ChatRoomService.java
@@ -1,13 +1,13 @@
 package com.greeny.ecomate.websocket.service;
 
+import com.greeny.ecomate.challenge.entity.MyChallenge;
+import com.greeny.ecomate.challenge.repository.MyChallengeRepository;
 import com.greeny.ecomate.exception.NotFoundException;
 import com.greeny.ecomate.exception.UnauthorizedAccessException;
 import com.greeny.ecomate.member.entity.Member;
 import com.greeny.ecomate.member.repository.MemberRepository;
-import com.greeny.ecomate.websocket.dto.ChatRoomResponseDto;
-import com.greeny.ecomate.websocket.dto.CreateChatRoomRequestDto;
-import com.greeny.ecomate.websocket.dto.MemberToChatRoomDto;
-import com.greeny.ecomate.websocket.dto.UpdateChatRoomRequestDto;
+import com.greeny.ecomate.utils.imageUtil.ImageUtil;
+import com.greeny.ecomate.websocket.dto.*;
 import com.greeny.ecomate.websocket.entity.ChatJoin;
 import com.greeny.ecomate.websocket.entity.ChatRoom;
 import com.greeny.ecomate.websocket.repository.ChatJoinRepository;
@@ -29,7 +29,10 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatJoinRepository chatJoinRepository;
+    private final MyChallengeRepository myChallengeRepository;
     private final MemberRepository memberRepository;
+
+    private final ImageUtil imageUtil;
 
     @Transactional
     public Long createRoom(CreateChatRoomRequestDto dto, Long memberId) {
@@ -62,6 +65,23 @@ public class ChatRoomService {
             chatRoomList.add(createChatRoomResponseDto(chatRoom.getRoomId(), memberNicknameList, chatRoom.getName()));
         }
         return chatRoomList;
+    }
+
+    public List<ChallengeStatusDto> getChallengeStatusByChatRoom(Long roomId, Long memberId) {
+        if (chatJoinRepository.findChatJoinByRoomIdAndMemberId(roomId, memberId).isEmpty()) {
+            throw new UnauthorizedAccessException("해당 채팅방에 대한 권한이 없습니다.");
+        }
+        List<Member> memberList = chatJoinRepository.findChatJoinsByChatRoom_RoomId(roomId)
+                .stream().map(ChatJoin::getMember).toList();
+
+        return memberList.stream().map(member ->
+            new ChallengeStatusDto(
+                  member.getNickname(),
+                  imageUtil.getProfileImage(member.getProfileImage()),
+                  myChallengeRepository.findAllByMember(member)
+                          .stream().mapToLong(this::getTotalDoneCnt).sum()
+            )
+        ).toList();
     }
 
     public ChatRoomResponseDto createChatRoomResponseDto(Long roomId, List<String> memberNicknameList, String name) {
@@ -128,6 +148,10 @@ public class ChatRoomService {
 
         chatJoinRepository.delete(chatJoin);
         return "채팅방 나가기 성공";
+    }
+
+    private Long getTotalDoneCnt(MyChallenge myChallenge) {
+        return (myChallenge.getAchieveCnt() - 1) * myChallenge.getChallenge().getGoalCnt() + myChallenge.getDoneCnt();
     }
 
 }


### PR DESCRIPTION
resolve #111 

### 추가 기능
- 채팅방 내 멤버들의 챌린지 현황 조회 기능 추가
  - 멤버들의 전체 챌린지 달성 횟수 기준으로 현황 조회
 
### 수정 사항
- 이미지 관련 로직을 ImageUtil 로 분리
 